### PR TITLE
Automated trimming from OBS timecodes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,13 +47,6 @@ jobs:
           version-command: |
             bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
 
-      - name: Bump version for developmental release
-        if: "! steps.check-version.outputs.tag"
-        run: |
-          poetry version patch &&
-          version=$(poetry version | awk '{ print $2 }') &&
-          poetry version $version.dev.$(date +%s)
-
       - name: Build package
         run: |
           poetry build --ansi

--- a/obs-scripts/log_scene_changes.lua
+++ b/obs-scripts/log_scene_changes.lua
@@ -1,0 +1,44 @@
+obs = obslua
+last_scene_name = ""
+log_file_path = os.getenv("HOME") .. "/" .. os.time() .. "-scene_changes.txt"
+
+function script_description()
+    return "This script logs scene changes to a file when OBS is live or recording."
+end
+
+function log_scene_change(scene_name, timestamp)
+    local file, err = io.open(log_file_path, "a")
+    if err then
+        print("Failed to open " .. log_file_path .. " for writing")
+    else
+        file:write(timestamp .. ":" .. scene_name .. "\n")
+        file:close()
+    end
+end
+
+function on_event(event)
+    print(event)
+    if event == obs.OBS_FRONTEND_EVENT_STREAMING_STARTED or event == obs.OBS_FRONTEND_EVENT_RECORDING_STARTED then
+        local scene = obs.obs_frontend_get_current_scene()
+        local scene_name = obs.obs_source_get_name(scene)
+        obs.obs_source_release(scene)
+        last_scene_name = scene_name
+        local timestamp = obs.obs_get_video_frame_time()  -- get the current time as the timestamp for starting streaming or recording
+        log_scene_change(scene_name, timestamp)  -- log the initial scene
+    end
+
+    if event == obs.OBS_FRONTEND_EVENT_SCENE_CHANGED then
+        local scene = obs.obs_frontend_get_current_scene()
+        local scene_name = obs.obs_source_get_name(scene)
+        obs.obs_source_release(scene)
+        if scene_name ~= last_scene_name and (obs.obs_frontend_streaming_active() or obs.obs_frontend_recording_active()) then
+            last_scene_name = scene_name
+            local timestamp = obs.obs_get_video_frame_time()
+            log_scene_change(scene_name, timestamp)
+        end
+    end
+end
+
+function script_load(settings)
+    obs.obs_frontend_add_event_callback(on_event)
+end


### PR DESCRIPTION
This gets us feature-parity with @ihorner's original Axehand script, and cleans up the CLI a little bit to make having multiple filters a bit less obtuse. This will require a bit of refactoring to cleanly allow for multiple `filter-cut` filters.

### Tasks
- [x] Write OBS lua script for dumping timecodes of scene changes (see notes).
- [ ] Rename `process-video` to `filter-cut`, add a repeatable `--filter=<timecodes|signature>` flag; process filters in order. Remove concat logic, see #27.
- [ ] Add CLI flag to main for `--timecodes [file]` to specify file, or expect timecode file in same directory as input clip (the latter matching Axehand's behaviour).
- [ ] Build `filter_cut` filter function for parsing timecode file into windows.

### Notes

1. Writing the OBS script in lua is annoying, but means that users don't have to install Python locally to use the timecode feature. In an ideal world it would be Python, but it's a small enough script that I can live with it.
2. I've included a small release fix in here, bad practice but since I'm the only contributor I'm the only one that has to be angry about it.